### PR TITLE
✨ 졸업생 성적조회기능 대응

### DIFF
--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -21,6 +21,7 @@ export default {
   '/std/cps/atnlc/popup/LectrePlanStdNumPopup.do': handleLenturePlan,
   '/std/cps/atnlc/LectrePlanGdhlStdPage.do': handleSyllabusGraduate,
   '/std/cps/inqire/AtnlcScreStdPage.do': handleScore,
+  '/std/cps/inqire/GradScreStdPage.do': handleScore,
   '/std/cps/inqire/StandStdPage.do': handleRank,
   '/std/lis/evltn/LctrumHomeStdPage.do': handleLectureHome,
   '/std/cps/inqire/LctreEvlViewStdPage.do': handleEvaluation,


### PR DESCRIPTION
- 기존 재학생 성정조회 기능을 졸업생에 대해서도 동작하도록 대응했습니다.
- 재학생과 졸업생 성적조회 URI가 다릅니다.
  - 재학생: `/std/cps/inqire/AtnlcScreStdPage.do`
  - 졸업생: `/std/cps/inqire/GradScreStdPage.do`

resolve #31 